### PR TITLE
documentation cleanup

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -14,7 +14,7 @@ The OpenAPI description of this group, will be available by default on:
 
 To enable the support of multiple OpenAPI definitions, a bean of type `GroupedOpenApi` needs to be defined.
 
-For the following Group definition(based on package path), the OpenAPI description url will be :  /v3/api-docs/**stores**
+For the following Group definition(based on package path), the OpenAPI description URL will be :  /v3/api-docs/**stores**
 ```java
 @Bean
 public GroupedOpenApi storeOpenApi() {
@@ -24,7 +24,7 @@ public GroupedOpenApi storeOpenApi() {
 }
 ```
 
-For the following Group definition (based on package name), the OpenAPI description url will be:  /v3/api-docs/**users**
+For the following Group definition (based on package name), the OpenAPI description URL will be:  /v3/api-docs/**users**
 ```java
 @Bean
 public GroupedOpenApi userOpenApi() {
@@ -34,7 +34,7 @@ public GroupedOpenApi userOpenApi() {
 }
 ```
 
-For the following Group definition(based on path), the OpenAPI description url will be:  /v3/api-docs/**pets**
+For the following Group definition(based on path), the OpenAPI description URL will be:  /v3/api-docs/**pets**
 ```java
 @Bean
 public GroupedOpenApi petOpenApi() {
@@ -44,7 +44,7 @@ public GroupedOpenApi petOpenApi() {
 }
 ```
 
-For the following Group definition (based on package name and path), the OpenAPI description url will be:  /v3/api-docs/**groups**
+For the following Group definition (based on package name and path), the OpenAPI description URL will be:  /v3/api-docs/**groups**
 ```java
 @Bean
 public GroupedOpenApi groupOpenApi() {
@@ -71,11 +71,11 @@ springdoc.swagger-ui.filter=group-a
 ```
 
 ### How can I disable/enable Swagger UI generation based on env variable?
-- This property helps you disable only the ui.
+- This property helps you disable only the UI.
 ```properties
 springdoc.swagger-ui.enabled=false
 ```
-### How can I control the default expansion setting for the operations and tags, in the Swagger Ui ,
+### How can I control the default expansion setting for the operations and tags, in the Swagger UI ,
 - You can set this property in your application.yml like so for example:
 ```properties
 springdoc.swagger-ui.doc-expansion= none
@@ -135,7 +135,7 @@ springdoc.packagesToScan=package1, package2
 </dependency>
 ```
 
-### Is there a gradle plugin available?
+### Is there a Gradle plugin available?
 - There is no `springdoc-gradle-plugin` planned for short term.
 
 ### How can I hide a parameter from the documentation ?
@@ -171,7 +171,7 @@ The projects that uses `spring-data` should add this dependency together with th
 ```
 
 - If you use Pageable in a GET HTTP method, you will have to declare the explicit mapping of Pageable fields as Query Params and add the @Parameter(hidden = true) Pageable pageable on your pageable parameter.
-- You should also, declare the annotation `@PageableAsQueryParam` provided by springdoc on the method level, or declare your own if need to define your custom description, defaultvalue, ...
+- You should also, declare the annotation `@PageableAsQueryParam` provided by springdoc on the method level, or declare your own if need to define your custom description, defaultValue, ...
 - Since, v1.3.1 you can use as well `@ParameterObject` instead of `@PageableAsQueryParam` for HTTP `GET` methods.
 
 
@@ -196,10 +196,10 @@ public String toString() {
 }
 ```
 
-### Does it really support Spring Boot 2.2.x.RELEASE & Hateoas 1.0? 
+### Does it really support Spring Boot 2.2.x.RELEASE & HATEOAS 1.0? 
 - Yes
 
-### How can I deploy the Doploy `springdoc-openapi-ui`, behind a reverse proxy?
+### How can I deploy `springdoc-openapi-ui` behind a reverse proxy?
 - If your application is running behind a proxy, a load-balancer or in the cloud, the request information (like the host, port, scheme…​) might change along the way. Your application may be running on `10.10.10.10:8080`, but HTTP clients should only see `example.org`.
 
 - [RFC7239 "Forwarded Headers"](https://tools.ietf.org/html/rfc7239) defines the Forwarded HTTP header; proxies can use this header to provide information about the original request. You can configure your application to read those headers and automatically use that information when creating links and sending them to clients in HTTP 302 responses, JSON documents or HTML pages. There are also non-standard headers, like `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`, `X-Forwarded-Ssl`, and `X-Forwarded-Prefix`.
@@ -239,7 +239,7 @@ springdoc.swagger-ui.path= /swagger-ui/api-docs.html
 ```
 
 ### How can I test the Swagger UI?
-- You can have a look on this sample test of the ui:
+- You can have a look on this sample test of the UI:
 - [https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java](https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java).
 
 ### How can I customise the OpenAPI object ?
@@ -255,7 +255,7 @@ return openApi -> openApi.getPaths().values().stream().flatMap(pathItem -> pathI
 }
 ```
 
-### How to include` spring-boot-actuator` endpoints to Swagger Ui?
+### How to include` spring-boot-actuator` endpoints to Swagger UI?
 - In order to display `spring-boot-actuator` endpoints, you will need to add the following property:
 ```properties
 springdoc.show-actuator=true
@@ -265,7 +265,7 @@ springdoc.show-actuator=true
 - It is be possible to handle as return an empty content as response using, one of the following syntaxes:
   - `content = @Content`
   - `content = @Content(schema = @Schema(hidden = true))`
-- For exmaple:
+- For example:
 ```java
 @Operation(summary = "Get thing", responses = {
 		@ApiResponse(description = "Successful Operation", responseCode = "200", content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -312,7 +312,7 @@ ResponseEntity<String> testme() {
 ### Differentiation to Springfox project
 
 - OAS 3 was released in July 2017, and there was no release of `springfox` to support OAS 3.
-`springfox` covers for the moment only swagger 2 integration with Spring Boot. The lastest release date is june 2018. So, in terms of maintenance there is a big lack of support lately.
+`springfox` covers for the moment only swagger 2 integration with Spring Boot. The latest release date is June 2018. So, in terms of maintenance there is a big lack of support lately.
 
 - We decided to move forward and share the library that we already used on our internal projects, with the community.
 - The biggest difference with `springfox`, is that we integrate new features not covered by `springfox`:
@@ -326,14 +326,14 @@ ResponseEntity<String> testme() {
 - There is no relation between `springdoc-openapi` and `springfox`.If you want to migrate to OpenAPI 3:
   - Remove all the dependencies and the related code to springfox
   - Add `springdoc-openapi-ui` dependency
-- If you don't want to serve the ui from your root path or there is a conflict with an existing configuration, you can just change the following property:
+- If you don't want to serve the UI from your root path or there is a conflict with an existing configuration, you can just change the following property:
 ```properties
 springdoc.swagger-ui.path=/you-path/swagger-ui.html
 ```
 
 ### How can I set a global header?
 - You may have global parameters with Standard OpenAPI description.
-- If you need the defintions to appear globally (withing every group), no matter if the group fulfills the conditions specified on the GroupedOpenApi , you can use OpenAPI Bean.
+- If you need the definitions to appear globally (within every group), no matter if the group fulfills the conditions specified on the GroupedOpenApi , you can use OpenAPI Bean.
 - You can define common parameters under parameters in the global components section and reference them elsewhere via `$ref`. You can also define global header parameters.
 - For this, you can override to OpenAPI Bean, and set the global headers or parameters definition on the components level.
 ```java
@@ -386,26 +386,26 @@ public OpenAPI customOpenAPI() {
     .version("100")).addTagsItem(new Tag().name("mytag"));
 }
 ```
-###  Can i use spring property with swagger annotations?
+###  Can I use spring property with swagger annotations?
 - The support of spring property resolver for `@Info`: `title` - `description` - `version` - `termsOfService`
 - The support of spring property resolver for `@Info.license`: `name` - `url`
 - The support of spring property resolver for `@Info.contact`: `name` - `email` - `url`
 - The support of spring property resolver for `@Operation`: `description` - `summary`
 - The support of spring property resolver for `@Parameter`: `description` - `name`
 - The support of spring property resolver for `@ApiResponse`: `description`
-- Its also possible to declare security urls for `@OAuthFlow`: `openIdConnectUrl` - `authorizationUrl` - `refreshUrl` - `tokenUrl` 
+- Its also possible to declare security URLs for `@OAuthFlow`: `openIdConnectUrl` - `authorizationUrl` - `refreshUrl` - `tokenUrl` 
 - The support of spring property resolver for `@Schema`: `name` - `title` - `description` , by setting `springdoc.api-docs.resolve-schema-properties` to `true` 
-### How can i disable springdoc-openapi cache?
+### How can I disable springdoc-openapi cache?
 - By default, the OpenAPI description is calculated once, and then cached.
-- Sometimes the same swagger-ui is served behind internal and external proxies. some users want the server url, to be computed on each http request.
+- Sometimes the same swagger-ui is served behind internal and external proxies. some users want the server URL, to be computed on each http request.
 - In order to disable springdoc cache, you will have to set the following property:
 ```properties
 springdoc.cache.disabled= true
 ```
 
 
-###  How is server url generated ?
-- Generating automatically server url may be useful, if the documentation is not present.
+###  How is server URL generated ?
+- Generating automatically server URL may be useful, if the documentation is not present.
 - If the server annotations are present, they will be used instead.
 
 ### How can I expose the api-docs endpoints without using the `swagger-ui`?
@@ -437,18 +437,18 @@ OR
 @ApiResponse(responseCode = "404", description = "Not found", content = @Content)
 ```
 
-### What is the url of the `swagger-ui`, when I set a different context-path?
+### What is the URL of the `swagger-ui`, when I set a different context-path?
 
 - If you use different context-path:
 ```properties
 server.servlet.context-path= /foo
 ```
-- The `swagger-ui` will be available on the following url:
+- The `swagger-ui` will be available on the following URL:
   - http://server:port/foo/swagger-ui.html
 
 ### Can I customize OpenAPI object programmatically?
 
-- You can Define your own OpenAPI Bean: If you need the defintions to appear globally (withing every group), no matter if the group fulfills the conditions specified on the GroupedOpenApi , you can use OpenAPI Bean.
+- You can Define your own OpenAPI Bean: If you need the definitions to appear globally (within every group), no matter if the group fulfills the conditions specified on the GroupedOpenApi , you can use OpenAPI Bean.
 
 ```java
 @Bean
@@ -460,7 +460,7 @@ public OpenAPI customOpenAPI(@Value("${springdoc.version}") String appVersion) {
             .license(new License().name("Apache 2.0").url("http://springdoc.org")));
 }
 ```
-- If you need the defintions to appear withing a specific group, and respect the conditions specified on the GroupedOpenApi, you can add OpenApiCustomiser to your GroupedOpenApi definition.
+- If you need the definitions to appear within a specific group, and respect the conditions specified on the GroupedOpenApi, you can add OpenApiCustomiser to your GroupedOpenApi definition.
 
 ```java
 GroupedOpenApi.builder().setGroup("users").pathsToMatch(paths).packagesToScan(packagedToMatch).addOpenApiCustomiser(customerGlobalHeaderOpenApiCustomiser())
@@ -477,7 +477,7 @@ public OpenApiCustomiser customerGlobalHeaderOpenApiCustomiser() {
 
 
 ### Where can I find the source code of the demo applications?
-- The source code of the application is available at the following github repository:
+- The source code of the application is available at the following GitHub repository:
   - [https://github.com/springdoc/springdoc-openapi-demos.git](https://github.com/springdoc/springdoc-openapi-demos.git).
 
 ### Does this library supports annotations from interfaces?
@@ -530,7 +530,7 @@ springdoc.swagger-ui.url=/api-docs.yaml
 ### My Rest Controller using @Controller annotation is ignored?
 - This is the default behaviour if your `@Controller` doesn't have annotation `@ResponseBody`
 - You can change your controllers to `@RestControllers`. Or add `@ResponseBody` + `@Controller`.
-- If its not possible, you can configure sprindoc to scan you additionnal controller using SpringDocUtils. For example:
+- If its not possible, you can configure springdoc to scan you additional controller using SpringDocUtils. For example:
 
 ```java
 static {
@@ -538,7 +538,7 @@ static {
 }
 ```
 
-### How can i define groups using application.yml?
+### How can I define groups using application.yml?
 - You can load groups dynamically using spring-boot configuration files. 
 - Note that, for this usage, you don't have to declare the **GroupedOpenApi** Bean.
 - You need to declare the following properties, under the prefix **springdoc.group-configs**.
@@ -551,15 +551,15 @@ springdoc.group-configs[0].packages-to-scan=test.org.springdoc.api
 - The list of properties under this prefix, are available here:
   - https://springdoc.org/springdoc-properties.html#springdoc-openapi-core-properties
 
-### How can i extract fields from parameter object ?
+### How can I extract fields from parameter object ?
 - You can use springdoc annotation @ParameterObject. 
 - Request parameter annotated with @ParameterObject will help adding each field of the parameter as a separate request parameter. 
 - This is compatible with Spring MVC request parameters mapping to POJO object.
 - This annotation does not support nested parameter objects.
 
-### Where can i find a tutorial of using springdoc-openapi ?
+### Where can I find a tutorial of using springdoc-openapi ?
  - [Baeldung](https://www.baeldung.com/spring-rest-openapi-documentation)
- - [Dzone](https://dzone.com/articles/openapi-3-documentation-with-spring-boot)
+ - [DZone](https://dzone.com/articles/openapi-3-documentation-with-spring-boot)
  - [Piotrminkowski Blog](https://piotrminkowski.com/2020/02/20/microservices-api-documentation-with-springdoc-openapi/)
 
 ### How to Integrate Open API 3 with Spring project (not Spring Boot)?
@@ -577,7 +577,7 @@ For example, lets assume you want load the swagger-ui in spring-mvc application:
 </dependency>
 ```
 		
-- If you don't have the spring-boot and spring-boot-autoconfigure dependencies, you need to add them. And pay attention to the compatibility matrix, between you spring.verion and spring-boot.version. For example, in this case (spring.version=5.1.12.RELEASE):
+- If you don't have the spring-boot and spring-boot-autoconfigure dependencies, you need to add them. And pay attention to the compatibility matrix, between you spring.version and spring-boot.version. For example, in this case (spring.version=5.1.12.RELEASE):
 
 ```xml
 <dependency>

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ layout: default
 
 # **Introduction**
 
-springdoc-openapi java library helps automating the generation of API documentation using spring boot projects.
+springdoc-openapi Java library helps automating the generation of API documentation using spring boot projects.
 springdoc-openapi works by examining an application at runtime to infer API semantics based on spring configurations, class structure and various annotations.
 
 Automatically generates documentation in JSON/YAML and HTML format APIs. 
@@ -16,7 +16,7 @@ This library supports:
 *  Spring-boot (v1 and v2)
 *  JSR-303, specifically for @NotNull, @Min, @Max, and @Size.
 *  Swagger-ui
-*  Oauth 2
+*  OAuth 2
 
 This is a community-based project, not maintained by the Spring Framework Contributors (Pivotal)
 
@@ -25,7 +25,7 @@ This is a community-based project, not maintained by the Spring Framework Contri
 ## Library for springdoc-openapi integration with spring-boot and swagger-ui 
 *   Automatically deploys swagger-ui to a spring-boot application
 *   Documentation will be available in HTML format, using the official [swagger-ui jars](https://github.com/swagger-api/swagger-ui.git).
-*   The Swagger UI page should then be available at http://server:port/context-path/swagger-ui.html and the OpenAPI description will be available at the following url for json format: http://server:port/context-path/v3/api-docs
+*   The Swagger UI page should then be available at http://server:port/context-path/swagger-ui.html and the OpenAPI description will be available at the following URL for json format: http://server:port/context-path/v3/api-docs
     * server: The server name or IP
     * port: The server port
     * context-path: The context path of the application
@@ -46,8 +46,8 @@ This is a community-based project, not maintained by the Spring Framework Contri
 springdoc.swagger-ui.path=/swagger-ui.html
 ```
 
-## Integration of the libray in a spring-boot project without the swagger-ui:
-*   Documentation will be available at the following url for json format: http://server:port/context-path/v3/api-docs
+## Integration of the library in a spring-boot project without the swagger-ui:
+*   Documentation will be available at the following URL for json format: http://server:port/context-path/v3/api-docs
     * server: The server name or IP
     * port: The server port
     * context-path: The context path of the application
@@ -68,7 +68,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
 ```
 
-*   For wildfly users, you need to add the following dependency to make the swagger-ui work:
+*   For WildFly users, you need to add the following dependency to make the swagger-ui work:
 
 ```xml
    <dependency>
@@ -78,7 +78,7 @@ springdoc.api-docs.path=/api-docs
    </dependency>
 ```
 
-# **Additonnal settings**
+# **Additional settings**
 
 ## Adding API Information and Security documentation
   The library uses spring-boot application auto-configured packages to scan for the following annotations in spring beans: OpenAPIDefinition and Info.
@@ -123,7 +123,7 @@ For the list of paths to include, use the following property:
 springdoc.pathsToMatch=/v1, /api/balance/**
 ```
 
-## Spring-weblfux support with Annotated Controllers
+## Spring WebFlux support with Annotated Controllers
 *   Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yml
 *   Add the library to the list of your project dependencies (No additional configuration is needed)
 
@@ -164,8 +164,8 @@ This dependency helps ignoring @AuthenticationPrincipal in case its used on REST
 ```
 
 ## Kotlin support
-For a project that uses kotlin, you should add the following dependency, together with the springdoc-openapi-ui dependency:
-This dependency improves the support of kotlin types:
+For a project that uses Kotlin, you should add the following dependency, together with the springdoc-openapi-ui dependency:
+This dependency improves the support of Kotlin types:
 ```xml
    <dependency>
       <groupId>org.springdoc</groupId>
@@ -176,7 +176,7 @@ This dependency improves the support of kotlin types:
 
 ## Groovy support
 For a project that uses Groovy, you should add the following dependency, together with the springdoc-openapi-ui dependency:
-This dependency improves the support of kotlin types:
+This dependency improves the support of Kotlin types:
 ```xml
    <dependency>
       <groupId>org.springdoc</groupId>
@@ -192,7 +192,7 @@ The aim of springdoc-openapi-maven-plugin is to generate json and yaml OpenAPI d
 The plugin works during integration-tests phase, and generate the OpenAPI description. 
 The plugin works in conjunction with spring-boot-maven plugin. 
 
-You can test it during the integration tests phase using the maven command:
+You can test it during the integration tests phase using the Maven command:
 
 ```protobuf
 mvn verify -Dspring.application.admin.enabled=true
@@ -263,9 +263,9 @@ For more custom configuration of springdoc-openapi-gradle-plugin ,you can consul
 
 # **springdoc applications demos**
 
-## [Demo Spring Boot 2 webmvc with OpenAPI 3](https://springdoc-openapi-test-app2-silly-numbat.eu-de.mybluemix.net/).
-## [Demo Spring Boot 2 webflux with OpenAPI 3](https://springdoc-openapi-test-app3-terrific-rabbit.eu-de.mybluemix.net/swagger-ui.html).
-## [Demo Spring Boot 1 webmvc with OpenAPI 3](https://springdoc-openapi-test-app1-courteous-puku.eu-de.mybluemix.net/).
+## [Demo Spring Boot 2 Web MVC with OpenAPI 3](https://springdoc-openapi-test-app2-silly-numbat.eu-de.mybluemix.net/).
+## [Demo Spring Boot 2 WebFlux with OpenAPI 3](https://springdoc-openapi-test-app3-terrific-rabbit.eu-de.mybluemix.net/swagger-ui.html).
+## [Demo Spring Boot 1 Web MVC with OpenAPI 3](https://springdoc-openapi-test-app1-courteous-puku.eu-de.mybluemix.net/).
 
 ![Branching](https://springdoc.org/assets/images/pets.png)
 
@@ -274,7 +274,7 @@ For more custom configuration of springdoc-openapi-gradle-plugin ,you can consul
 
 ## Dependencies repository
 
-The springdoc-openapi libraries are hosted on maven central repository. 
+The springdoc-openapi libraries are hosted on Maven central repository. 
 The artifacts can be viewed accessed at the following locations:
 
 Releases:

--- a/springdoc-properties.md
+++ b/springdoc-properties.md
@@ -25,7 +25,7 @@ springdoc.default-produces-media-type | `*/*` | `String`.The default produces me
 springdoc.cache.disabled | `false` | `Boolean`. To disable the springdoc-openapi cache of the the calculated OpenAPI. 
 springdoc.show-actuator | `false` |  `Boolean`. To display the actuator endpoints.
 springdoc.auto-tag-classes | `true` | `Boolean`. To disable the springdoc-openapi automatic tags.
-springdoc.model-and-view-allowed | `false` | `Boolean`. To allow RestControllers with ModelAndView return to appear in the OpenAPI descritpion.
+springdoc.model-and-view-allowed | `false` | `Boolean`. To allow RestControllers with ModelAndView return to appear in the OpenAPI description.
 springdoc.override-with-generic-response | `true` | `Boolean`. When true, automatically adds @ControllerAdvice responses to all the generated responses.
 springdoc.api-docs.groups.enabled | `true` | `Boolean`. To disable the springdoc-openapi groups.
 springdoc.group-configs[0].group | | `String`.The group name
@@ -33,9 +33,9 @@ springdoc.group-configs[0].packages-to-scan | `*`| `List of Strings`.The list of
 springdoc.group-configs[0].paths-to-match | `/*`| `List of Strings`.The list of paths to match for a group(comma separated)
 springdoc.group-configs[0].paths-to-exclude | ``| `List of Strings`.The list of paths to exclude for a group(comma separated)
 springdoc.group-configs[0].packages-to-exclude | | `List of Strings`.The list of packages to exclude for a group(comma separated)
-springdoc.webjars.prefix | `/webjars` |`String`, To change the webjars prefix that is visible the url of swagger-ui for spring-webflux.
+springdoc.webjars.prefix | `/webjars` |`String`, To change the webjars prefix that is visible the URL of swagger-ui for spring-webflux.
 springdoc.api-docs.resolve-schema-properties | `false` | `Boolean`. To enable  property resolver on @Schema (name, title and description).
-springdoc.remove-broken-reference-definitions | `true` | `Boolean`. To disable removal of broken reference defintions.
+springdoc.remove-broken-reference-definitions | `true` | `Boolean`. To disable removal of broken reference definitions.
 
 ### swagger-ui properties
 - The support of the swagger-ui properties is available on `springdoc-openapi`.  See [Official documentation](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/).
@@ -68,8 +68,8 @@ springdoc.swagger-ui.supportedSubmitMethods |  | `Array=["get", "put", "post", "
 springdoc.swagger-ui.urls[0].url |  | `URL`. The url of the swagger group, used by Topbar plugin.  URLs must be unique among all items in this array, since they're used as identifiers.
 springdoc.swagger-ui.urls[0].name |  | `String`. The name of the swagger group, used by Topbar plugin.  Names must be unique among all items in this array, since they're used as identifiers.
 springdoc.swagger-ui.oauth.clientId |  | `String`. Default clientId. MUST be a string.
-springdoc.swagger-ui.oauth.clientSecret |  | `String`.  Default clientSecret. Never use this parameter in your production environment. It exposes cruicial security information. This feature is intended for dev/test environments only.
-springdoc.swagger-ui.oauth.realm |  | `String`. realm query parameter (for oauth1) added to authorizationUrl and tokenUrl.
+springdoc.swagger-ui.oauth.clientSecret |  | `String`.  Default clientSecret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only.
+springdoc.swagger-ui.oauth.realm |  | `String`. realm query parameter (for OAuth 1) added to authorizationUrl and tokenUrl.
 springdoc.swagger-ui.oauth.appName |  | `String`. OAuth application name, displayed in authorization popup.
 springdoc.swagger-ui.oauth.scopeSeparator |  | `String`. OAuth scope separator for passing scopes, encoded before calling, default value is a space (encoded value %20).
 springdoc.swagger-ui.oauth.additionalQueryStringParams |  | `String`. Additional query parameters added to authorizationUrl and tokenUrl.

--- a/src/main/resources/index.md
+++ b/src/main/resources/index.md
@@ -16,7 +16,7 @@ This library supports:
 *  Spring-boot (v1 and v2)
 *  JSR-303, specifically for @NotNull, @Min, @Max, and @Size.
 *  Swagger-ui
-*  Oauth 2
+*  OAuth 2
 
 This is a community-based project, not maintained by the Spring Framework Contributors (Pivotal)
 
@@ -46,7 +46,7 @@ This is a community-based project, not maintained by the Spring Framework Contri
 springdoc.swagger-ui.path=/swagger-ui.html
 ```
 
-## Integration of the libray in a spring-boot project without the swagger-ui:
+## Integration of the library in a spring-boot project without the swagger-ui:
 *   Documentation will be available at the following url for json format: http://server:port/context-path/v3/api-docs
     * server: The server name or IP
     * port: The server port
@@ -68,7 +68,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
 ```
 
-*   For wildfly users, you need to add the following dependency to make the swagger-ui work:
+*   For WildFly users, you need to add the following dependency to make the swagger-ui work:
 
 ```xml
    <dependency>
@@ -78,7 +78,7 @@ springdoc.api-docs.path=/api-docs
    </dependency>
 ```
 
-# **Additonnal settings**
+# **Additional settings**
 
 ## Adding API Information and Security documentation
   The library uses spring-boot application auto-configured packages to scan for the following annotations in spring beans: OpenAPIDefinition and Info.
@@ -164,8 +164,8 @@ This dependency helps ignoring @AuthenticationPrincipal in case its used on REST
 ```
 
 ## Kotlin support
-For a project that uses kotlin, you should add the following dependency, together with the springdoc-openapi-ui dependency:
-This dependency improves the support of kotlin types:
+For a project that uses Kotlin, you should add the following dependency, together with the springdoc-openapi-ui dependency:
+This dependency improves the support of Kotlin types:
 ```xml
    <dependency>
       <groupId>org.springdoc</groupId>
@@ -176,7 +176,7 @@ This dependency improves the support of kotlin types:
 
 ## Groovy support
 For a project that uses Groovy, you should add the following dependency, together with the springdoc-openapi-ui dependency:
-This dependency improves the support of kotlin types:
+This dependency improves the support of Kotlin types:
 ```xml
    <dependency>
       <groupId>org.springdoc</groupId>
@@ -263,9 +263,9 @@ For more custom configuration of springdoc-openapi-gradle-plugin ,you can consul
 
 # **springdoc applications demos**
 
-## [Demo Spring Boot 2 webmvc with OpenAPI 3](https://springdoc-openapi-test-app2-silly-numbat.eu-de.mybluemix.net/).
-## [Demo Spring Boot 2 webflux with OpenAPI 3](https://springdoc-openapi-test-app3-terrific-rabbit.eu-de.mybluemix.net/swagger-ui.html).
-## [Demo Spring Boot 1 webmvc with OpenAPI 3](https://springdoc-openapi-test-app1-courteous-puku.eu-de.mybluemix.net/).
+## [Demo Spring Boot 2 Web MVC with OpenAPI 3](https://springdoc-openapi-test-app2-silly-numbat.eu-de.mybluemix.net/).
+## [Demo Spring Boot 2 WebFlux with OpenAPI 3](https://springdoc-openapi-test-app3-terrific-rabbit.eu-de.mybluemix.net/swagger-ui.html).
+## [Demo Spring Boot 1 Web MVC with OpenAPI 3](https://springdoc-openapi-test-app1-courteous-puku.eu-de.mybluemix.net/).
 
 ![Branching](https://springdoc.org/assets/images/pets.png)
 


### PR DESCRIPTION
To make the documentation more professional and readable, this commit fixes misspellings and capitalization.