### PR TITLE
fixed Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 cache: bundler
 rvm: 2.6
 
-install: script/bootstrap
-script: script/cibuild
+install: bash script/bootstrap
+script: bash script/cibuild


### PR DESCRIPTION
fixes #9 

This doesn't make the build pass because there are actual problems being caught by `htmlproofer` are visible now, so the build will still fail with 1. This is definitely a step in the right direction though.

peek

```bash
$ bash script/cibuild
Configuration file: /home/travis/build/aubrey-y/springdoc.github.io/_config.yml
 Theme Config file: /home/travis/build/aubrey-y/springdoc.github.io/_config.yml
            Source: /home/travis/build/aubrey-y/springdoc.github.io
       Destination: /home/travis/build/aubrey-y/springdoc.github.io/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
                    done in 0.298 seconds.
 Auto-regeneration: disabled. Use --watch to enable.
Running ["HtmlCheck", "ImageCheck", "LinkCheck", "ScriptCheck"] on ["./_site"] on *.html... 
Checking 47 external links...
Ran on 6 files!
- ./_site/faq.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
- ./_site/index.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
- ./_site/migrating-from-springfox.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
- ./_site/springdoc-properties.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
  *  internally linking to /docs/usage/deep-linking.md, which does not exist (line 267)
     <a href="/docs/usage/deep-linking.md">Deep Linking documentation</a>
- ./_site/src/main/resources/index.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
- ./_site/src/main/resources/migrating-from-springfox.html
  *  SRI and CORS not provided in: https://www.googletagmanager.com/gtag/js?id=UA-143834491-1 (line 6)
htmlproofer 3.15.3 | Error:  HTML-Proofer found 7 failures!
The command "bash script/cibuild" exited with 1.
cache.2
store build cache
$ bundle clean
Cleaning all the gems on your system is dangerous! If you're sure you want to
remove every system gem not in this bundle, run `bundle clean --force`.
0.00s0.93schanges detected, packing new archive
uploading issue-9/cache--linux-xenial-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855--rvm-2.6--gemfile-Gemfile.tgz
cache uploaded
Done. Your build exited with 1.
```