### PR TITLE
Springfox to springdoc

### DIFF
--- a/docs/core-properties.html
+++ b/docs/core-properties.html
@@ -206,7 +206,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 20:17:44 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/demos.html
+++ b/docs/demos.html
@@ -63,7 +63,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:19:06 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -1613,7 +1613,7 @@ You can use the following property that is available since release v1.4.3:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:20:43 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/features.html
+++ b/docs/features.html
@@ -271,7 +271,7 @@ springdoc-openpi scans for a unique route related to a @RouterOperation annotati
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:13:31 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -85,7 +85,7 @@ springdoc.swagger-ui.path=/swagger-ui.html</code></pre>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 18:24:17 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,11 @@
 <li><a href="#source-code-of-the-demo-applications">7.2. Source code of the Demo Applications</a></li>
 </ul>
 </li>
-<li><a href="#migrating-from-springfox">8. Migrating from SpringFox</a></li>
+<li><a href="#migrating-from-springfox">8. Migrating from SpringFox</a>
+<ul class="sectlevel2">
+<li><a href="#migrating-using-tool">8.1. Migrating using tool</a></li>
+</ul>
+</li>
 <li><a href="#other-resources">9. Other resources</a>
 <ul class="sectlevel2">
 <li><a href="#additional-resources-to-get-started">9.1. Additional resources to get started</a></li>
@@ -1497,6 +1501,13 @@ springdoc.pathsToMatch=/v1, /api/balance/**</code></pre>
 </div>
 </li>
 </ul>
+</div>
+<div class="sect2">
+<h3 id="migrating-using-tool"><a class="anchor" href="#migrating-using-tool"></a>8.1. Migrating using tool</h3>
+<div class="paragraph">
+<p>springfox-to-springdoc is a simple migration tool which traverse ast and migrates code springfox to springdoc. For more
+details see <a href="https://github.com/MobilizIT/springfox-to-springdoc" class="bare">github.com/MobilizIT/springfox-to-springdoc</a></p>
+</div>
 </div>
 </div>
 </div>
@@ -3169,7 +3180,7 @@ You can use the following property that is available since release v1.4.3:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:15:53 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/intro.html
+++ b/docs/intro.html
@@ -67,7 +67,7 @@ This documentation can be completed by comments using swagger-api annotations.</
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 18:58:08 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/migrating-from-springfox.html
+++ b/docs/migrating-from-springfox.html
@@ -196,12 +196,19 @@ springdoc.pathsToMatch=/v1, /api/balance/**</code></pre>
 </li>
 </ul>
 </div>
+<div class="sect2">
+<h3 id="_migrating_using_tool">Migrating using tool</h3>
+<div class="paragraph">
+<p>springfox-to-springdoc is a simple migration tool which traverse ast and migrates code springfox to springdoc. For more
+details see <a href="https://github.com/MobilizIT/springfox-to-springdoc" class="bare">https://github.com/MobilizIT/springfox-to-springdoc</a></p>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 18:51:16 +0100
+Last updated 2020-11-09 13:45:36 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -225,7 +225,7 @@ This dependency improves the support of Kotlin types:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:10:40 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/other-resources.html
+++ b/docs/other-resources.html
@@ -75,7 +75,7 @@ The artifacts can be viewed accessed at the following locations:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-02 10:14:06 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -137,7 +137,7 @@ The plugin works in conjunction with spring-boot-maven plugin.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:17:31 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/properties.html
+++ b/docs/properties.html
@@ -454,7 +454,7 @@ All these properties should be declared with the following prefix: <code>springd
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 19:06:09 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/thanks.html
+++ b/docs/thanks.html
@@ -41,7 +41,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 21:03:37 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/docs/ui-properties.html
+++ b/docs/ui-properties.html
@@ -241,7 +241,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-11-01 20:17:05 +0100
+Last updated 2020-11-09 13:39:02 +0300
 </div>
 </div>
 <link rel="stylesheet" href="js/highlight/styles/github.min.css">

--- a/src/docs/asciidoc/migrating-from-springfox.adoc
+++ b/src/docs/asciidoc/migrating-from-springfox.adoc
@@ -106,3 +106,8 @@ springdoc.pathsToMatch=/v1, /api/balance/**
    ** link:index.html#how-can-i-configure-swagger-ui[how-can-i-configure-swagger-ui]
 * To hide an operation or a controller from documentation
    ** link:index.html#how-can-i-hide-an-operation-or-a-controller-from-documentation[how-can-i-hide-an-operation-or-a-controller-from-documentation]
+
+=== Migrating using tool
+
+springfox-to-springdoc is a simple migration tool which traverse ast and migrates code springfox to springdoc. For more
+details see https://github.com/MobilizIT/springfox-to-springdoc

--- a/src/docs/asciidoc/migrating-from-springfox.adoc
+++ b/src/docs/asciidoc/migrating-from-springfox.adoc
@@ -109,5 +109,11 @@ springdoc.pathsToMatch=/v1, /api/balance/**
 
 === Migrating using tool
 
-springfox-to-springdoc is a simple migration tool which traverse ast and migrates code springfox to springdoc. For more
-details see https://github.com/MobilizIT/springfox-to-springdoc
+springfox-to-springdoc is a simple migration tool which traverse ast and migrates your code from springfox to springdoc.
+
+[source,shell script]
+----
+java -jar springfox-to-springdoc.jar -i /path/to/java/files
+----
+
+For more information. Please see: https://github.com/MobilizIT/springfox-to-springdoc


### PR DESCRIPTION
We create a simple tool to migrate project from springfox to springdoc. It is not complete yet but works for most cases. We create it for our projects. And we want to make it free software. In this PR, I added tool usage description into migration guide to make migration process easier to people who want to switch to springdoc.