### PR TITLE
Demonstrate annotation filtering in SpringDoc

### DIFF
--- a/src/docs/asciidoc/migrating-from-springfox.adoc
+++ b/src/docs/asciidoc/migrating-from-springfox.adoc
@@ -49,6 +49,7 @@ Before:
               .select()
               .apis(RequestHandlerSelectors.basePackage("org.github.springshop.web.admin"))
               .paths(PathSelectors.regex("/admin.*"))
+              .apis(RequestHandlerSelectors.withMethodAnnotation(Admin.class))
               .build()
               .groupName("springshop-admin")
               .apiInfo(apiInfo());
@@ -71,6 +72,7 @@ Now:
       return GroupedOpenApi.builder()
               .group("springshop-admin")
               .pathsToMatch("/admin/**")
+              .addMethodFilter(method -> method.isAnnotationPresent(Admin.class))
               .build();
   }
 ----


### PR DESCRIPTION
Springfox allowed filtering of endpoints by method and class annotation, thereby allowing more granular filtering than the package or path filtering originally available in SpringDoc. As the implementation of an  `OpenApiMethodFilter` has now been introduced into SpringDoc, the equivalent functionality of SpringDoc annotation filtering is now available, so a suitable example is now being included in the migration documentation.