### PR TITLE
Fix typo of spring-data-commons

### DIFF
--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -171,13 +171,14 @@ springdoc.packagesToScan=package1, package2
 === Are the following validation annotations supported : `@NotEmpty` `@NotBlank` `@PositiveOrZero` `@NegativeOrZero`?
 * Yes
 
-===  How can I map `Pageable` (spring-date-commons) object to correct URL-Parameter in Swagger UI?
+===  How can I map `Pageable` (spring-data-commons) object to correct URL-Parameter in Swagger UI?
 
 The support for Pageable of spring-data-commons is available out-of-the box since `springdoc-openapi v1.6.0`.
 For this, you have to combine `@ParameterObject` annotation with the `Pageable` type.
 
 
 Before `springdoc-openapi v1.6.0`:
+
 * You can use as well `@ParameterObject` instead of `@PageableAsQueryParam` for HTTP `GET` methods.
 
 [source,java]

--- a/src/docs/asciidoc/v2/faq.adoc
+++ b/src/docs/asciidoc/v2/faq.adoc
@@ -163,13 +163,14 @@ springdoc.packagesToScan=package1, package2
 === Are the following validation annotations supported : `@NotEmpty` `@NotBlank` `@PositiveOrZero` `@NegativeOrZero`?
 * Yes
 
-===  How can I map `Pageable` (spring-date-commons) object to correct URL-Parameter in Swagger UI?
+===  How can I map `Pageable` (spring-data-commons) object to correct URL-Parameter in Swagger UI?
 
 The support for Pageable of spring-data-commons is available out-of-the box since `springdoc-openapi v1.6.0`.
 For this, you have to combine `@ParameterObject` annotation with the `Pageable` type.
 
 
 Before `springdoc-openapi v1.6.0`:
+
 * You can use as well `@ParameterObject` instead of `@PageableAsQueryParam` for HTTP `GET` methods.
 
 [source,java]


### PR DESCRIPTION
Fix typo of spring-data-commons, also fixes the first item to be `<li>` in the following screenshot.

![image](https://user-images.githubusercontent.com/6624567/152315390-73459d35-fb59-40e9-a2cc-a8e229ebc4dd.png)

By the way, instead of having the `docs` folder in the `master` branch, I think separating the `gh-pages` branch and set up some CI (like GitHub Actions) to sync from the source will be much better.