### PR TITLE
@ParameterObject: getters with mandatory `get` prefix

### DIFF
--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -635,6 +635,7 @@ springdoc.group-configs[0].packages-to-scan=test.org.springdoc.api
 * Request parameter annotated with @ParameterObject will help adding each field of the parameter as a separate request parameter.
 * This is compatible with Spring MVC request parameters mapping to POJO object.
 * This annotation does not support nested parameter objects.
+* POJO object must contain getters for fields with mandatory prefix `get`. Otherwise, the swagger documentation will not show the fields of the annotated entity.
 
 === How to Integrate Open API 3 with Spring project (not Spring Boot)?
 When your application is using spring without (spring-boot), you need to add beans and  auto-configuration that are natively provided in spring-boot.


### PR DESCRIPTION
Closes: #32 