### PR TITLE
Add note about @ParameterObject in the migrating-from-springfox section

### DIFF
--- a/src/docs/asciidoc/migrating-from-springfox.adoc
+++ b/src/docs/asciidoc/migrating-from-springfox.adoc
@@ -26,6 +26,8 @@ Package for swagger 3 annotations is `io.swagger.v3.oas.annotations`.
 - `@ApiParam` -> `@Parameter`
 - `@ApiResponse(code = 404, message = "foo")` -> `@ApiResponse(responseCode = "404", description = "foo")`
 
+* If you're using an object to capture multiple request query params, annotation that method argument with `@ParameterObject`
+
 * This step is optional: Only if you have **multiple** `Docket` beans replace them with `GroupedOpenApi` beans.
 
 Before:


### PR DESCRIPTION
I stumbled with this on the first migration and thought the `@ParameterObject` annotation should be made visible in this scetion