### PR TITLE
Fix typo of springdoc.model-converters.deprecating-converter.enabled

### DIFF
--- a/docs/core-properties.html
+++ b/docs/core-properties.html
@@ -194,7 +194,7 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -253,7 +253,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-07-13 11:04:53 +0900
 </div>
 </div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,8 +7,6 @@
 <meta name="generator" content="Asciidoctor 2.0.15">
 <meta name="author" content="OpenAPI 3 Library for spring-boot By Badr NASS LAHSEN">
 <title>OpenAPI 3 Library for spring-boot</title>
-<meta name="author" content="OpenAPI 3 Library for spring-boot By Badr NASS LAHSEN">
-<title>OpenAPI 3 Library for spring-boot</title>
 <meta property="og:title" content="OpenAPI 3 Library for spring-boot" />
 <meta property="og:locale" content="en_US" />
 <meta name="description" content="OpenAPI 3 Library for spring boot projects. Is based on swagger-ui, to display the OpenAPI description.Generates automatically the OpenAPI file." />
@@ -1422,7 +1420,7 @@ For that, <code>@RouterOperation</code> fields must help identify uniquely the c
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -4183,7 +4181,7 @@ public class OpenApiConfig {
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-07-13 11:04:53 +0900
 </div>
 </div>
 <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/docs/properties.html
+++ b/docs/properties.html
@@ -202,7 +202,7 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -525,7 +525,7 @@ All these properties should be declared with the following prefix: <code>springd
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-02-03 18:14:22 +0900
 </div>
 </div>
 </div>

--- a/docs/v2/core-properties.html
+++ b/docs/v2/core-properties.html
@@ -194,7 +194,7 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -283,7 +283,7 @@
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-07-13 11:04:53 +0900
 </div>
 </div>
 </div>

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -1276,7 +1276,7 @@ For that, <code>@RouterOperation</code> fields must help identify uniquely the c
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -3951,7 +3951,7 @@ public class OpenApiConfig {
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-07-13 11:04:53 +0900
 </div>
 </div>
 <!-- Global site tag (gtag.js) - Google Analytics -->

--- a/docs/v2/properties.html
+++ b/docs/v2/properties.html
@@ -202,7 +202,7 @@
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To enable pretty print of the OpenApi specification.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters. deprecating-converter.enabled</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">springdoc.model-converters.deprecating-converter.enabled</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>true</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code>. To disable deprecating model converter.</p></td>
 </tr>
@@ -525,7 +525,7 @@ All these properties should be declared with the following prefix: <code>springd
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-06-07 13:58:13 +0200
+Last updated 2022-02-03 18:14:22 +0900
 </div>
 </div>
 </div>

--- a/src/docs/asciidoc/core-properties.adoc
+++ b/src/docs/asciidoc/core-properties.adoc
@@ -33,7 +33,7 @@
 |springdoc.api-docs.resolve-schema-properties | `false` | `Boolean`. To enable  property resolver on @Schema (name, title and description).
 |springdoc.remove-broken-reference-definitions | `true` | `Boolean`. To disable removal of broken reference definitions.
 |springdoc.writer-with-default-pretty-printer | `false` | `Boolean`. To enable pretty print of the OpenApi specification.
-|springdoc.model-converters. deprecating-converter.enabled | `true` | `Boolean`. To disable deprecating model converter.
+|springdoc.model-converters.deprecating-converter.enabled | `true` | `Boolean`. To disable deprecating model converter.
 |springdoc.model-converters.polymorphic-converter.enabled | `true` | `Boolean`. To disable polymorphic model converter.
 |springdoc.model-converters.pageable-converter.enabled | `true` | `Boolean`. To disable pageable model converter.
 |springdoc.use-fqn | `false` | `Boolean`. To enable fully qualified names.

--- a/src/docs/asciidoc/v2/core-properties.adoc
+++ b/src/docs/asciidoc/v2/core-properties.adoc
@@ -33,7 +33,7 @@
 |springdoc.api-docs.resolve-schema-properties | `false` | `Boolean`. To enable  property resolver on @Schema (name, title and description).
 |springdoc.remove-broken-reference-definitions | `true` | `Boolean`. To disable removal of broken reference definitions.
 |springdoc.writer-with-default-pretty-printer | `false` | `Boolean`. To enable pretty print of the OpenApi specification.
-|springdoc.model-converters. deprecating-converter.enabled | `true` | `Boolean`. To disable deprecating model converter.
+|springdoc.model-converters.deprecating-converter.enabled | `true` | `Boolean`. To disable deprecating model converter.
 |springdoc.model-converters.polymorphic-converter.enabled | `true` | `Boolean`. To disable polymorphic model converter.
 |springdoc.model-converters.pageable-converter.enabled | `true` | `Boolean`. To disable pageable model converter.
 |springdoc.use-fqn | `false` | `Boolean`. To enable fully qualified names.


### PR DESCRIPTION
Remove space