### PR TITLE
Replace GlobalOpenApiCustomiser with GlobalOpenApiCustomizer

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -684,7 +684,7 @@ This bean <code>OpenApiCustomizer</code> will be applied to the Default OpenAPI 
 </table>
 </div>
 <div class="paragraph">
-<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomiser</code> instead.</p>
+<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomizer</code> instead.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3086,7 +3086,7 @@ This bean <code>OpenApiCustomizer</code> will be applied to the Default OpenAPI 
 </table>
 </div>
 <div class="paragraph">
-<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomiser</code> instead.</p>
+<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomizer</code> instead.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/v2/faq.html
+++ b/docs/v2/faq.html
@@ -675,7 +675,7 @@ This bean <code>OpenApiCustomizer</code> will be applied to the Default OpenAPI 
 </table>
 </div>
 <div class="paragraph">
-<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomiser</code> instead.</p>
+<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomizer</code> instead.</p>
 </div>
 </div>
 <div class="sect2">

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -2948,7 +2948,7 @@ This bean <code>OpenApiCustomizer</code> will be applied to the Default OpenAPI 
 </table>
 </div>
 <div class="paragraph">
-<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomiser</code> instead.</p>
+<p>If you need the <code>OpenApiCustomizer</code> to applied to <code>GroupedOpenApi</code> as well, then use <code>GlobalOpenApiCustomizer</code> instead.</p>
 </div>
 </div>
 <div class="sect2">

--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -314,7 +314,7 @@ return openApi -> openApi.getPaths().values().stream().flatMap(pathItem -> pathI
 
 NOTE: This bean `OpenApiCustomizer` will be applied to the Default OpenAPI only.
 
-If you need the `OpenApiCustomizer` to applied to `GroupedOpenApi` as well, then use `GlobalOpenApiCustomiser` instead.
+If you need the `OpenApiCustomizer` to applied to `GroupedOpenApi` as well, then use `GlobalOpenApiCustomizer` instead.
 
 === How can I return an empty content as response?
 * It is be possible to handle as return an empty content as response using, one of the following syntaxes:

--- a/src/docs/asciidoc/v2/faq.adoc
+++ b/src/docs/asciidoc/v2/faq.adoc
@@ -305,7 +305,7 @@ return openApi -> openApi.getPaths().values().stream().flatMap(pathItem -> pathI
 
 NOTE: This bean `OpenApiCustomizer` will be applied to the Default OpenAPI only.
 
-If you need the `OpenApiCustomizer` to applied to `GroupedOpenApi` as well, then use `GlobalOpenApiCustomiser` instead.
+If you need the `OpenApiCustomizer` to applied to `GroupedOpenApi` as well, then use `GlobalOpenApiCustomizer` instead.
 
 === How can I return an empty content as response?
 * It is be possible to handle as return an empty content as response using, one of the following syntaxes:


### PR DESCRIPTION
Replace `GlobalOpenApiCustomiser` with [GlobalOpenApiCustomizer](https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-common/src/main/java/org/springdoc/core/customizers/GlobalOpenApiCustomizer.java) (`s`/`z`), because `GlobalOpenApiCustomiser ` doesn't exist.