### PR TITLE
Fix incorrect URL to Swagger UI in getting-started

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -53,7 +53,7 @@
 <p>Documentation will be available in HTML format, using the official <a href="https://github.com/swagger-api/swagger-ui.git" target="_blank" rel="noopener">swagger-ui jars</a></p>
 </li>
 <li>
-<p>The Swagger UI page will then be available at <code>http://server:port/context-path/swagger-ui.html</code> and the OpenAPI description will be available at the following url for json format: <code>http://server:port/context-path/v3/api-docs</code></p>
+<p>The Swagger UI page will then be available at <code>http://server:port/context-path/swagger-ui/index.html</code> and the OpenAPI description will be available at the following url for json format: <code>http://server:port/context-path/v3/api-docs</code></p>
 <div class="ulist">
 <ul>
 <li>


### PR DESCRIPTION
I'm an absolute newbie in the Kotlin world so it could just as well be that I'm doing something odd here, but following this guide, I discovered that the file was served at swagger-ui/index.html and not swagger-ui.html.