### PR TITLE
Fix incorrect demo URL in v2

### DIFF
--- a/src/docs/asciidoc/v2/demos.adoc
+++ b/src/docs/asciidoc/v2/demos.adoc
@@ -13,4 +13,4 @@
 image::img/pets.png[pets.png]
 
 === Source code of the Demo Applications
-*   link:https://github.com/springdoc/springdoc-openapi-demos.git[https://github.com/springdoc/springdoc-openapi-demos.git, window="_blank"]
+*   link:https://github.com/springdoc/springdoc-openapi-demos.git[https://github.com/springdoc/springdoc-openapi-demos/tree/2.x, window="_blank"]

--- a/src/docs/asciidoc/v2/demos.adoc
+++ b/src/docs/asciidoc/v2/demos.adoc
@@ -13,4 +13,4 @@
 image::img/pets.png[pets.png]
 
 === Source code of the Demo Applications
-*   link:https://github.com/springdoc/springdoc-openapi-demos.git[https://github.com/springdoc/springdoc-openapi-demos/tree/2.x, window="_blank"]
+*   link:https://github.com/springdoc/springdoc-openapi-demos/tree/2.x[https://github.com/springdoc/springdoc-openapi-demos/tree/2.x, window="_blank"]


### PR DESCRIPTION
While looking at the [springdoc v2 guide](https://springdoc.org/v2/#source-code-of-the-demo-applications), I found that the demo is referring to v1 demo, not the demo of v2. Regarding this, I changed url to 2.x branch.

_If this is a problem caused by a demo not yet updated on the master branch, it seems necessary to add a explanation to the official document._

Thank you.