### PR TITLE
Unify the parameter name of core-properties to kebab-case

### DIFF
--- a/src/docs/asciidoc/core-properties.adoc
+++ b/src/docs/asciidoc/core-properties.adoc
@@ -21,7 +21,7 @@
 |springdoc.override-with-generic-response | `true` | `Boolean`. When true, automatically adds @ControllerAdvice responses to all the generated responses.
 |springdoc.api-docs.groups.enabled | `true` | `Boolean`. To disable the springdoc-openapi groups.
 |springdoc.group-configs[0].group | | `String`.The group name
-|springdoc.group-configs[0].displayName | | `String`.The display name of the group.
+|springdoc.group-configs[0].display-name | | `String`.The display name of the group.
 |springdoc.group-configs[0].packages-to-scan | `*`| `List of Strings`.The list of packages to scan for a group (comma separated)
 |springdoc.group-configs[0].paths-to-match | `/*`| `List of Strings`.The list of paths to match for a group(comma separated)
 |springdoc.group-configs[0].paths-to-exclude | ``| `List of Strings`.The list of paths to exclude for a group(comma separated)
@@ -45,7 +45,7 @@
 |springdoc.disable-i18n | `false` | `Boolean`. To disable automatic translation using i18n.
 |springdoc.show-spring-cloud-functions | `true` |  `Boolean`. To display the spring-cloud-function web endpoints.
 |springdoc.api-docs.version | `openapi_3_0` | `String`. To Choose `OpenAPI 3.0` or `OpenAPI 3.1` (using the value `OPENAPI_3_1`).
-|springdoc.default-flat-paramObject | `false` | `Boolean`. To default flatten parameter.
+|springdoc.default-flat-param-object | `false` | `Boolean`. To default flatten parameter.
 |springdoc.default-support-form-data | `false` | `Boolean`. To default set parameters to form data when specifying api to accept form data.
 |springdoc.nullable-request-parameter-enabled | `true` | `Boolean`. To default Enable Support for nullable request parameters in Kotlin.
 |springdoc.show-oauth2-endpoint | `false` | `Boolean`. To make spring security oauth2-endpoint visible.

--- a/src/docs/asciidoc/v2/core-properties.adoc
+++ b/src/docs/asciidoc/v2/core-properties.adoc
@@ -21,7 +21,7 @@
 |springdoc.override-with-generic-response | `true` | `Boolean`. When true, automatically adds @ControllerAdvice responses to all the generated responses.
 |springdoc.api-docs.groups.enabled | `true` | `Boolean`. To disable the springdoc-openapi groups.
 |springdoc.group-configs[0].group | | `String`.The group name
-|springdoc.group-configs[0].displayName | | `String`.The display name of the group.
+|springdoc.group-configs[0].display-name | | `String`.The display name of the group.
 |springdoc.group-configs[0].packages-to-scan | `*`| `List of Strings`.The list of packages to scan for a group (comma separated)
 |springdoc.group-configs[0].paths-to-match | `/*`| `List of Strings`.The list of paths to match for a group(comma separated)
 |springdoc.group-configs[0].paths-to-exclude | ``| `List of Strings`.The list of paths to exclude for a group(comma separated)
@@ -51,7 +51,7 @@
 |springdoc.enable-hateoas | `true` |  `Boolean`. To enable spring-hateoas support.
 |springdoc.enable-data-rest | `true` |  `Boolean`. To enable spring-data-rest support.
 |springdoc.api-docs.version | `openapi_3_0` | `String`. To Choose `OpenAPI 3.0` or `OpenAPI 3.1` (using the value `OPENAPI_3_1`).
-|springdoc.default-flat-paramObject | `false` | `Boolean`. To default flatten parameter.
+|springdoc.default-flat-param-object | `false` | `Boolean`. To default flatten parameter.
 |springdoc.default-support-form-data | `false` | `Boolean`. To default set parameters to form data when specifying api to accept form data.
 |springdoc.nullable-request-parameter-enabled | `true` | `Boolean`. To default Enable Support for nullable request parameters in Kotlin.
 |springdoc.show-oauth2-endpoint | `false` | `Boolean`. To make spring security oauth2-endpoint visible.


### PR DESCRIPTION
Only a few of the parameter names in core-properties are in camel case, but I will modify them to kebab-case to match the rest.

URL: https://springdoc.org/#springdoc-openapi-core-properties

example

![スクリーンショット 2023-03-31 21 53 56](https://user-images.githubusercontent.com/36355491/229125883-709aa8a3-b906-4e33-b44a-b5d076edc1e7.png)
