### PR TITLE
Added @Primay to code examples for setting Swagger properties program…

### DIFF
--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -145,6 +145,7 @@ These can be set by creating a `swaggerUiConfig` bean as follows:
 [source,kotlin]
 ---
 @Bean
+@Primary
 fun swaggerUiConfig(config: SwaggerUiConfigProperties): SwaggerUiConfigProperties {
     config.showCommonExtensions = true
     config.queryConfigEnabled = true

--- a/src/docs/asciidoc/v2/faq.adoc
+++ b/src/docs/asciidoc/v2/faq.adoc
@@ -145,6 +145,7 @@ These can be set by creating a `swaggerUiConfig` bean as follows:
 [source,kotlin]
 ---
 @Bean
+@Primary
 fun swaggerUiConfig(config: SwaggerUiConfigProperties): SwaggerUiConfigProperties {
     config.showCommonExtensions = true
     config.queryConfigEnabled = true


### PR DESCRIPTION
issue: [#2234](https://github.com/springdoc/springdoc-openapi/issues/2234)

Corrected because `SwaggerConfig required a single bean` error is output when @Primary is not attached.