### PR TITLE
doc: change the example in migrating-from-springfox.html

### DIFF
--- a/docs/migrating-from-springfox.html
+++ b/docs/migrating-from-springfox.html
@@ -71,7 +71,7 @@ Package for swagger 3 annotations is <code>io.swagger.v3.oas.annotations</code>.
 <p><code>@ApiModel</code> &#8594; <code>@Schema</code></p>
 </li>
 <li>
-<p><code>@ApiModelProperty(hidden = true)</code> &#8594; <code>@Schema(accessMode = READ_ONLY)</code></p>
+<p><code>@ApiModelProperty(allowEmptyValue = true)</code> &#8594; <code>@Schema(nullable = true)</code></p>
 </li>
 <li>
 <p><code>@ApiModelProperty</code> &#8594; <code>@Schema</code></p>


### PR DESCRIPTION
I think `@ApiModelProperty(hidden = true))` should be `@Schema(hidden = true)`.
I'll recommend another example.