### PR TITLE
fix(modules.webflux): fix typo

### DIFF
--- a/src/docs/asciidoc/modules.adoc
+++ b/src/docs/asciidoc/modules.adoc
@@ -42,7 +42,7 @@ springdoc.api-docs.path=/api-docs
 ----
    <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webflux-api</artifactId>
       <version>{springdoc-version}</version>
    </dependency>
 ----


### PR DESCRIPTION
# Description
* Fix a typo 'springdoc-openapi-starter-webflux-ui' -> 'springdoc-openapi-starter-webflux-api'

# How to review?
* In this section https://springdoc.org/#spring-webflux-support, it's talking about JSON / YAML format which is provided by the  '*-api' dependency and not the '*-ui' one
  * Check https://springdoc.org/#general-overview 