### PR TITLE
Update demos links for Spring 3.x

### DIFF
--- a/src/docs/asciidoc/demos.adoc
+++ b/src/docs/asciidoc/demos.adoc
@@ -13,4 +13,4 @@
 image::img/pets.png[pets.png]
 
 === Source code of the Demo Applications
-*   link:https://github.com/springdoc/springdoc-openapi-demos/tree/2.x[https://github.com/springdoc/springdoc-openapi-demos/tree/2.x, window="_blank"]
+*   link:https://github.com/springdoc/springdoc-openapi-demos/tree/master[https://github.com/springdoc/springdoc-openapi-demos/tree/master, window="_blank"]


### PR DESCRIPTION
The link was pointing to the 2.x branch, giving the impression that Spring Boot 3.x was not really 'supported' in the demos.

I assume this is not intentional. If it is, feel free to close this PR.