### PR TITLE
doc(properties): fix proper springConfigurationProperty link

### DIFF
--- a/src/docs/asciidoc/properties.adoc
+++ b/src/docs/asciidoc/properties.adoc
@@ -1,7 +1,7 @@
 [[properties]]
 == Springdoc-openapi Properties
 
-`springdoc-openapi` relies on standard link:https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config[spring configuration properties, window="_blank"] (yml or properties) using the standard files locations.
+`springdoc-openapi` relies on standard link:https://docs.spring.io/spring-boot/reference/features/external-config.html[spring configuration properties, window="_blank"] (yml or properties) using the standard files locations.
 
 
 === springdoc-openapi core properties


### PR DESCRIPTION
# Description
* Fix to proper springConfigurationProperty link

# How to review?
* Check that the existing link --  https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config -- does NOT exist anymore
* The replacement for this page is https://docs.spring.io/spring-boot/reference/features/external-config.html