### PR TITLE
docs: fix typo in YAML documentation path description

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -69,7 +69,7 @@
 </div>
 </li>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 </ul>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,7 @@ This documentation can be completed by comments using swagger-api annotations.</
 </div>
 </li>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 </ul>
 </div>
@@ -460,7 +460,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 <li>
 <p>Add the library to the list of your project dependencies (No additional configuration is needed)</p>

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -113,7 +113,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 <li>
 <p>Add the library to the list of your project dependencies (No additional configuration is needed)</p>

--- a/docs/v1/getting-started.html
+++ b/docs/v1/getting-started.html
@@ -69,7 +69,7 @@
 </div>
 </li>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 </ul>
 </div>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -323,7 +323,7 @@ This documentation can be completed by comments using swagger-api annotations.</
 </div>
 </li>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 </ul>
 </div>
@@ -431,7 +431,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 <li>
 <p>Add the library to the list of your project dependencies (No additional configuration is needed)</p>

--- a/docs/v1/modules.html
+++ b/docs/v1/modules.html
@@ -113,7 +113,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <div class="ulist">
 <ul>
 <li>
-<p>Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
+<p>Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml</p>
 </li>
 <li>
 <p>Add the library to the list of your project dependencies (No additional configuration is needed)</p>

--- a/src/docs/asciidoc/getting-started.adoc
+++ b/src/docs/asciidoc/getting-started.adoc
@@ -20,7 +20,7 @@ This will automatically deploy swagger-ui to a spring-boot application:
 **  server: The server name or IP
 **  port: The server port
 **  context-path: The context path of the application
-*   Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml
+*   Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml
 
 TIP: For custom path of the swagger documentation in HTML format, add a custom springdoc property, in your spring-boot configuration file: .
 

--- a/src/docs/asciidoc/modules.adoc
+++ b/src/docs/asciidoc/modules.adoc
@@ -35,7 +35,7 @@ springdoc.api-docs.path=/api-docs
 
 === Spring WebFlux support
 
-*   Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml
+*   Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml
 *   Add the library to the list of your project dependencies (No additional configuration is needed)
 
 [source,xml, subs="attributes+"]

--- a/src/docs/asciidoc/v1/getting-started.adoc
+++ b/src/docs/asciidoc/v1/getting-started.adoc
@@ -20,7 +20,7 @@ This will automatically deploy swagger-ui to a spring-boot application:
 **  server: The server name or IP
 **  port: The server port
 **  context-path: The context path of the application
-*   Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml
+*   Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml
 
 TIP: For custom path of the swagger documentation in HTML format, add a custom springdoc property, in your spring-boot configuration file: .
 

--- a/src/docs/asciidoc/v1/modules.adoc
+++ b/src/docs/asciidoc/v1/modules.adoc
@@ -35,7 +35,7 @@ springdoc.api-docs.path=/api-docs
 
 === Spring WebFlux support
 
-*   Documentation can be available in yaml format as well, on the following path : /v3/api-docs.yaml
+*   Documentation will be available in yaml format as well, on the following path : /v3/api-docs.yaml
 *   Add the library to the list of your project dependencies (No additional configuration is needed)
 
 [source,xml, subs="attributes+"]


### PR DESCRIPTION
Small typo fix in documentation – changed "can" to "will" for clarity.