### PR TITLE
Add Gradle dependency example to Getting Started docs #94

### DIFF
--- a/src/docs/asciidoc/v4/getting-started.adoc
+++ b/src/docs/asciidoc/v4/getting-started.adoc
@@ -3,6 +3,7 @@
 
 For the integration between spring-boot and swagger-ui, add the library to the list of your project dependencies (No additional configuration is needed)
 
+=== Maven
 [source,xml, subs="attributes+"]
 ----
    <dependency>
@@ -12,6 +13,16 @@ For the integration between spring-boot and swagger-ui, add the library to the l
    </dependency>
 ----
 
+=== Gradle 
+[source,gradle, subs="attributes+"]
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:{springdoc-upcoming-version}'
+
+
+For example, using version 2.8.11:
+[source,gradle]
+----
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
+----
 
 This will automatically deploy swagger-ui to a spring-boot application:
 


### PR DESCRIPTION
## Description
Fixes #94 

Added Gradle dependency example to the Getting Started documentation.

## Changes
- Added Gradle dependency section with version placeholder
- Added concrete example using version 2.8.11