### PR TITLE
Update code links in documentation

### DIFF
--- a/docs/features.html
+++ b/docs/features.html
@@ -143,19 +143,19 @@ RouterFunction&lt;?&gt; routes() {
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/app90/HelloRouter.java">HelloRouter</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app90/HelloRouter.java">HelloRouter</a></p>
 </li>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/app90/quotes/QuotesRouter.java">QuotesRouter</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app90/quotes/QuotesRouter.java">QuotesRouter</a></p>
 </li>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/app90/book/BookRouter.java">BookRouter</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app90/book/BookRouter.java">BookRouter</a></p>
 </li>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/app90/employee/EmployeeRouter.java">EmployeeRouter</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app90/employee/EmployeeRouter.java">EmployeeRouter</a></p>
 </li>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/blob/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/app90/position/PositionRouter.java">PositionRouter</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app90/position/PositionRouter.java">PositionRouter</a></p>
 </li>
 </ul>
 </div>
@@ -312,7 +312,7 @@ For that, <code>@RouterOperation</code> fields must help identify uniquely the c
 <div class="ulist">
 <ul>
 <li>
-<p><a href="https://github.com/springdoc/springdoc-openapi/tree/master/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api" target="_blank" rel="noopener">Sample code with Functional Endpoints documentation</a></p>
+<p><a href="https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31" target="_blank" rel="noopener">Sample code with Functional Endpoints documentation</a></p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
The structure of the code repository has changed, causing some links in the documentation to become outdated. This pull request updates those links to point to the correct locations.