### PR TITLE
Update SwaggerUI dependency for WebFlux

### DIFF
--- a/src/docs/asciidoc/modules.adoc
+++ b/src/docs/asciidoc/modules.adoc
@@ -68,7 +68,7 @@ link:https://swagger.io/tools/swagger-ui/[Swagger UI] allows anyone — be it yo
 ----
    <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
       <version>{springdoc-version}</version>
    </dependency>
 ----


### PR DESCRIPTION
Currently both MVC and Flux are showing to use `springdoc-openapi-starter-webmvc-ui` for SwaggerUI, which does not work for reactive.

This change updates the docs to use `springdoc-openapi-starter-webflux-ui`.