### PR TITLE
Fix default-produces-media-type unescaped value

### DIFF
--- a/src/docs/asciidoc/core-properties.adoc
+++ b/src/docs/asciidoc/core-properties.adoc
@@ -13,7 +13,7 @@
 |springdoc.paths-to-exclude | | `List of Strings`. The list of paths to exclude (comma separated)
 |springdoc.packages-to-exclude | | `List of Strings`. The list of packages to exclude (comma separated)
 |springdoc.default-consumes-media-type | `application/json` | `String`. The default consumes media type.
-|springdoc.default-produces-media-type | `*/*` | `String`. The default produces media type.
+|springdoc.default-produces-media-type | `\*/*` | `String`. The default produces media type.
 |springdoc.cache.disabled | `false` | `Boolean`. To disable the springdoc-openapi cache of the calculated OpenAPI.
 |springdoc.show-actuator | `false` |  `Boolean`. To display the actuator endpoints.
 |springdoc.auto-tag-classes | `true` | `Boolean`. To disable the springdoc-openapi automatic tags.

--- a/src/docs/asciidoc/v1/core-properties.adoc
+++ b/src/docs/asciidoc/v1/core-properties.adoc
@@ -13,7 +13,7 @@
 |springdoc.paths-to-exclude | | `List of Strings`.The list of paths to exclude (comma separated)
 |springdoc.packages-to-exclude | | `List of Strings`.The list of packages to exclude (comma separated)
 |springdoc.default-consumes-media-type | `application/json` | `String`. The default consumes media type.
-|springdoc.default-produces-media-type | `*/*` | `String`.The default produces media type.
+|springdoc.default-produces-media-type | `\*/*` | `String`.The default produces media type.
 |springdoc.cache.disabled | `false` | `Boolean`. To disable the springdoc-openapi cache of the calculated OpenAPI.
 |springdoc.show-actuator | `false` |  `Boolean`. To display the actuator endpoints.
 |springdoc.auto-tag-classes | `true` | `Boolean`. To disable the springdoc-openapi automatic tags.

--- a/src/docs/asciidoc/v4/core-properties.adoc
+++ b/src/docs/asciidoc/v4/core-properties.adoc
@@ -13,7 +13,7 @@
 |springdoc.paths-to-exclude | | `List of Strings`. The list of paths to exclude (comma separated)
 |springdoc.packages-to-exclude | | `List of Strings`. The list of packages to exclude (comma separated)
 |springdoc.default-consumes-media-type | `application/json` | `String`. The default consumes media type.
-|springdoc.default-produces-media-type | `*/*` | `String`. The default produces media type.
+|springdoc.default-produces-media-type | `\*/*` | `String`. The default produces media type.
 |springdoc.cache.disabled | `false` | `Boolean`. To disable the springdoc-openapi cache of the calculated OpenAPI.
 |springdoc.show-actuator | `false` |  `Boolean`. To display the actuator endpoints.
 |springdoc.auto-tag-classes | `true` | `Boolean`. To disable the springdoc-openapi automatic tags.


### PR DESCRIPTION
Hello, here's my second attempt, modifying the source file instead of the generated html.

The previous value was transforming the double star-wrapped strings as a strong-formated strings.

Here's a preview of the issue, captured today on https://springdoc.org/properties.html:

<img width="877" height="59" alt="Capture d’écran 2026-01-26 à 16 47 25" src="https://github.com/user-attachments/assets/5bc9ed88-fef6-4696-b1e4-8bf9aeec1a65" />


Please let me know if there is something I can do to improve the PR.

It supersedes #103.