### PR TITLE
docs: update version references from 2.8.17 to 3.0.3

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -2004,7 +2004,7 @@ public class WebConfig implements WebApplicationInitializer {
 <p><code>springdoc-openapi 2.x</code> is compatible with <code>spring-boot 3</code>.</p>
 </div>
 <div class="paragraph">
-<p>In general, <strong>you should only pick the last stable version as per today 2.8.17.</strong></p>
+<p>In general, <strong>you should only pick the last stable version as per today 3.0.3.</strong></p>
 </div>
 <div class="paragraph">
 <p>More precisely, this the exhaustive list of spring-boot versions against which <code>springdoc-openapi</code> has been built:</p>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -40,7 +40,7 @@
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 <meta property="og:site_name" content="OpenAPI 3 Library for spring-boot" />
 <meta property="og:image" content="https://springdoc.org/img/banner-logo.svg" />
 <meta name="author" content="Library for OpenAPI 3 with spring-boot By Badr NASS LAHSEN">
-<title>springdoc-openapi v2.8.17</title>
+<title>springdoc-openapi v3.0.3</title>
 <link rel="stylesheet" href="css/site.css">
 <style>
     #header #revnumber {
@@ -53,7 +53,7 @@
   <div id="main" class="contained">
     <div id="doc" class="doc">
 <div id="header">
-<h1>springdoc-openapi v2.8.17</h1>
+<h1>springdoc-openapi v3.0.3</h1>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
@@ -319,7 +319,7 @@ This documentation can be completed by comments using swagger-api annotations.</
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -427,7 +427,7 @@ springdoc.swagger-ui.path=/swagger-ui.html</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-api&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -479,7 +479,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-api&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -501,7 +501,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -517,7 +517,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -560,7 +560,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -576,7 +576,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -1079,7 +1079,7 @@ You can declare it in your project as follows:</p>
             &lt;dependency&gt;
                 &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
                 &lt;artifactId&gt;springdoc-openapi-bom&lt;/artifactId&gt;
-                &lt;version&gt;2.8.17&lt;/version&gt;
+                &lt;version&gt;3.0.3&lt;/version&gt;
                 &lt;type&gt;pom&lt;/type&gt;
                 &lt;scope&gt;import&lt;/scope&gt;
             &lt;/dependency&gt;
@@ -2379,7 +2379,7 @@ Migration tips
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -4695,7 +4695,7 @@ public class WebConfig implements WebApplicationInitializer {
 <p><code>springdoc-openapi 2.x</code> is compatible with <code>spring-boot 3</code>.</p>
 </div>
 <div class="paragraph">
-<p>In general, <strong>you should only pick the last stable version as per today 2.8.17.</strong></p>
+<p>In general, <strong>you should only pick the last stable version as per today 3.0.3.</strong></p>
 </div>
 <div class="paragraph">
 <p>More precisely, this the exhaustive list of spring-boot versions against which <code>springdoc-openapi</code> has been built:</p>

--- a/docs/migrating-from-springfox.html
+++ b/docs/migrating-from-springfox.html
@@ -44,7 +44,7 @@
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -73,7 +73,7 @@
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-api&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -125,7 +125,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-api&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -147,7 +147,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -163,7 +163,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -206,7 +206,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -222,7 +222,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -725,7 +725,7 @@ You can declare it in your project as follows:</p>
 			&lt;dependency&gt;
 				&lt;groupId&gt;org.springdoc&lt;/groupId&gt;
 				&lt;artifactId&gt;springdoc-openapi-bom&lt;/artifactId&gt;
-                &lt;version&gt;2.8.17&lt;/version&gt;
+                &lt;version&gt;3.0.3&lt;/version&gt;
 				&lt;type&gt;pom&lt;/type&gt;
 				&lt;scope&gt;import&lt;/scope&gt;
 			&lt;/dependency&gt;

--- a/docs/v4/index.html
+++ b/docs/v4/index.html
@@ -529,7 +529,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -545,7 +545,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -588,7 +588,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -604,7 +604,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>

--- a/docs/v4/modules.html
+++ b/docs/v4/modules.html
@@ -147,7 +147,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -163,7 +163,7 @@ springdoc.api-docs.path=/api-docs</code></pre>
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-ui&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -206,7 +206,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webmvc-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>
@@ -222,7 +222,7 @@ You can rely on native Scalar configuration properties, using the prefix <code>s
 <pre class="highlight"><code class="language-xml" data-lang="xml">   &lt;dependency&gt;
       &lt;groupId&gt;org.springdoc&lt;/groupId&gt;
       &lt;artifactId&gt;springdoc-openapi-starter-webflux-scalar&lt;/artifactId&gt;
-      &lt;version&gt;2.8.17&lt;/version&gt;
+      &lt;version&gt;3.0.3&lt;/version&gt;
    &lt;/dependency&gt;</code></pre>
 </div>
 </div>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<version>3.1.2-SNAPSHOT</version>
 
 	<properties>
-		<springdoc.version>2.8.17</springdoc.version>
+		<springdoc.version>3.0.3</springdoc.version>
 		<springdoc-legacy.version>1.8.0</springdoc-legacy.version>
 		<springdoc-upcoming.version>3.0.3</springdoc-upcoming.version>
 		<java.version>1.8</java.version>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,7 +1,7 @@
 = springdoc-openapi v{springdoc-version}
 include::_attributes.adoc[]
 
-IMPORTANT: ``springdoc-openapi v1.8.0 `` is the latest Open Source release supporting Spring Boot 2.x and 1.x. +
+IMPORTANT: ``springdoc-openapi v3.0.3 `` is the latest Open Source release supporting Spring Boot 2.x and 1.x. +
 An extended support for https://springdoc.org/v1[*springdoc-openapi v1*] project is now available for organizations that need support beyond 2023. +
 For more details, feel free to reach out: sales@springdoc.org
 


### PR DESCRIPTION
## Summary
Updates all version references in the official documentation from `2.8.17` to `3.0.3`.

## Related Issue
Fixes springdoc/springdoc-openapi#3290

## Changes
- Updated page title in `index.adoc`
- Updated all Maven dependency `<version>` snippets
- Updated BOM version reference
- Updated version in `modules.adoc`

## Notes
`v3.0.3` is the latest stable release targeting Spring Boot 4.x.
No logic changes — documentation-only update.