### PR TITLE
Fix FAQ sample link

### DIFF
--- a/src/docs/asciidoc/faq.adoc
+++ b/src/docs/asciidoc/faq.adoc
@@ -60,7 +60,7 @@ public GroupedOpenApi groupOpenApi() {
 
 For more details about the usage, you can have a look at the following sample Test:
 
-* link:https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/java/test/org/springdoc/api/app68[https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/java/test/org/springdoc/api/app68, window="_blank"]
+* link:https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/java/test/org/springdoc/api/v31/app68[https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/java/test/org/springdoc/api/v31/app68, window="_blank"]
 
 === How can I configure Swagger UI?
 * The support of the swagger official properties is available on `springdoc-openapi`.  See link:https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/[Official documentation, window="_blank"].


### PR DESCRIPTION
## Summary

Fixes the FAQ sample test link that currently points to a non-existent `app68` directory.

The sample exists under the current v31 test path in `springdoc-openapi`, so this updates the AsciiDoc link target and visible URL to `/api/v31/app68`.

Fixes springdoc/springdoc.github.io#106.

## Evidence

- Issue: https://github.com/springdoc/springdoc.github.io/issues/106
- Duplicate PR check before edits: `gh pr list -R springdoc/springdoc.github.io --state open --search '106 OR #106 OR faq.adoc OR app68 OR springdoc-openapi-actuator-webmvc-tests' --json number,title,url,author,headRefName,baseRefName,updatedAt` returned `[]`.
- Current broken URL returned `HTTP_STATUS=404` before the edit.
- Updated URL returned `HTTP_STATUS=200` after the edit.

## Verification

- `curl -L -o /dev/null -s -w '%{http_code}' https://github.com/springdoc/springdoc-openapi/tree/main/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/java/test/org/springdoc/api/v31/app68` -> `200`
- `git diff --check` -> passed

Full docs generation was not run in this environment because `mvn` is not installed, there is no `mvnw` wrapper in the repository, and `asciidoctor` is not installed.
