### PR TITLE
docs(v2): refine the Spring Boot compatibility matrix

### DIFF
--- a/docs/v2/faq.html
+++ b/docs/v2/faq.html
@@ -2025,11 +2025,11 @@ public class WebConfig implements WebApplicationInitializer {
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.5.x</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.8.x</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.8.9</code> - <code>2.9.x</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.4.x</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.7.x</code> - <code>2.8.x</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.7.x</code> - <code>2.8.8</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.3.x</code></p></td>
@@ -2127,7 +2127,7 @@ This can be fixed by adding the <code>-parameters</code> arg to the Maven Compil
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-31 14:13:41 +0200
+Last updated 2026-08-03 17:55:44 +0900
 </div>
 </div>
 </div>

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -4705,11 +4705,11 @@ public class WebConfig implements WebApplicationInitializer {
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.5.x</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.8.x</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.8.9</code> - <code>2.9.x</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.4.x</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.7.x</code> - <code>2.8.x</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>2.7.x</code> - <code>2.8.8</code></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>3.3.x</code></p></td>
@@ -4807,7 +4807,7 @@ This can be fixed by adding the <code>-parameters</code> arg to the Maven Compil
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2026-07-30 23:57:46 +0200
+Last updated 2026-08-03 17:16:11 +0900
 </div>
 </div>
 </div>

--- a/src/docs/asciidoc/v2/faq.adoc
+++ b/src/docs/asciidoc/v2/faq.adoc
@@ -1072,8 +1072,8 @@ More precisely, this the exhaustive list of spring-boot versions against which `
 |===
 | Spring Boot Versions | Springdoc OpenAPI Versions
 |`4.x.x` | `3.x.x`
-|`3.5.x` | `2.8.x`
-|`3.4.x` | `2.7.x` - `2.8.x`
+|`3.5.x` | `2.8.9` - `2.9.x`
+|`3.4.x` | `2.7.x` - `2.8.8`
 |`3.3.x` | `2.6.x`
 |`3.2.x` | `2.3.x` - `2.5.x`
 |`3.1.x` | `2.2.x`


### PR DESCRIPTION
Related to springdoc/springdoc-openapi#3210.

The v2 compatibility matrix currently lists the entire `2.8.x` line under both Spring Boot 3.4 and 3.5, and does not include the current `2.9.x` release line.

The Spring Boot build baseline changed between springdoc-openapi `2.8.8` and `2.8.9`:

| springdoc-openapi | Spring Boot parent |
| ----------------- | ------------------ |
| `2.8.8`           | `3.4.5`            |
| `2.8.9`           | `3.5.0`            |
| `2.9.0`           | `3.5.16`           |

This updates the matrix to list `2.7.x`–`2.8.8` under Spring Boot 3.4 and `2.8.9`–`2.9.x` under Spring Boot 3.5.
